### PR TITLE
Update callback registration from old to new

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -337,7 +337,7 @@ class NationalParksSkill(MycroftSkill):
         self.nps = NPS(self.apiKey)
 
         # watch for changes on HOME
-        self.settings.set_changed_callback(self.on_websettings_changed)
+        self.settings_change_callback = self.on_websettings_changed
 
     def on_websettings_changed(self):
       


### PR DESCRIPTION
The old way has been deprecated since 19.08 and will stop working when v20.02 is released. This is a simple one-liner update and we'll update the skill in the skills repository once this is merged.

Thank you for contributing this skill to the Mycroft community!